### PR TITLE
Add `runar-examples` package and new example for serializer vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "runar-examples"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "ctor",
+ "runar-keys",
+ "runar-schemas",
+ "runar-serializer",
+ "runar_common 0.1.0",
+ "runar_macros",
+ "runar_macros_common",
+ "runar_node",
+ "runar_services",
+ "runar_test_utils",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "runar-keys"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "runar-common",
     "runar-services",
     "rust-examples/micro_services_demo",
+    "rust-examples",
     "runar-keys",
     "runar-ffi",
     "runar-gateway",

--- a/rust-examples/Cargo.toml
+++ b/rust-examples/Cargo.toml
@@ -15,7 +15,8 @@ runar_test_utils = { path = "../runar-test-utils" }
 runar_macros = { path = "../runar-macros" }
 runar_macros_common = { path = "../runar-macros-common" }
 runar-schemas = { path = "../runar-schemas" }
-runar-services = { path = "../runar-services" }
+# keep dependency name consistent with workspace: runar_services
+runar_services = { path = "../runar-services" }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -31,3 +32,7 @@ path = "simple/src/main.rs"
 [[example]]
 name = "micro_services_demo"
 path = "micro_services_demo/src/main.rs"
+
+[[example]]
+name = "serializer_vectors"
+path = "serializer_vectors.rs"

--- a/rust-examples/serializer_vectors.rs
+++ b/rust-examples/serializer_vectors.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use runar_serializer::{runar, ArcValue, Encrypt, Plain};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Plain)]
+pub struct PlainUser {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encrypt)]
+#[runar(name = "vectors.TestProfile")]
+pub struct TestProfile {
+    pub id: String,
+    #[runar(user)]
+    pub secret: String,
+}
+
+fn write_bytes(path: &Path, name: &str, bytes: &[u8]) -> Result<()> {
+    let mut p = path.to_path_buf();
+    p.push(name);
+    fs::write(p, bytes)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    // Output directory
+    let out = PathBuf::from("target/serializer-vectors");
+    fs::create_dir_all(&out)?;
+
+    // Primitives
+    write_bytes(
+        &out,
+        "prim_string.bin",
+        &ArcValue::new_primitive("hello".to_string()).serialize(None)?,
+    )?;
+    write_bytes(
+        &out,
+        "prim_bool.bin",
+        &ArcValue::new_primitive(true).serialize(None)?,
+    )?;
+    write_bytes(
+        &out,
+        "prim_i64.bin",
+        &ArcValue::new_primitive(42i64).serialize(None)?,
+    )?;
+    write_bytes(
+        &out,
+        "prim_u64.bin",
+        &ArcValue::new_primitive(7u64).serialize(None)?,
+    )?;
+
+    // Bytes
+    write_bytes(
+        &out,
+        "bytes.bin",
+        &ArcValue::new_bytes(vec![1, 2, 3]).serialize(None)?,
+    )?;
+
+    // JSON
+    let json = serde_json::json!({"a": 1, "b": [true, "x"]});
+    write_bytes(&out, "json.bin", &ArcValue::new_json(json).serialize(None)?)?;
+
+    // Heterogeneous list/map
+    let list_any = ArcValue::new_list(vec![
+        ArcValue::new_primitive(1i64),
+        ArcValue::new_primitive("two".to_string()),
+    ]);
+    write_bytes(&out, "list_any.bin", &list_any.serialize(None)?)?;
+
+    let mut map_any: HashMap<String, ArcValue> = HashMap::new();
+    map_any.insert("x".into(), ArcValue::new_primitive(10i64));
+    map_any.insert("y".into(), ArcValue::new_primitive("ten".to_string()));
+    let map_any = ArcValue::new_map(map_any);
+    write_bytes(&out, "map_any.bin", &map_any.serialize(None)?)?;
+
+    // Typed containers (no element encryption)
+    let list_typed = ArcValue::new_list::<i64>(vec![1, 2, 3]);
+    write_bytes(&out, "list_i64.bin", &list_typed.serialize(None)?)?;
+
+    let mut map_typed: HashMap<String, i64> = HashMap::new();
+    map_typed.insert("a".into(), 1);
+    map_typed.insert("b".into(), 2);
+    let map_typed = ArcValue::new_map::<i64>(map_typed);
+    write_bytes(&out, "map_string_i64.bin", &map_typed.serialize(None)?)?;
+
+    // Struct plain (derive Plain so it's allowed in ArcValue::new_struct)
+    let user = PlainUser {
+        id: "u1".into(),
+        name: "Alice".into(),
+    };
+    let av_user = ArcValue::new_struct(user);
+    write_bytes(&out, "struct_plain.bin", &av_user.serialize(None)?)?;
+
+    println!("Wrote serializer vectors to {}", out.display());
+    Ok(())
+}


### PR DESCRIPTION
- Introduced a new `runar-examples` package in the workspace, including dependencies for various utilities and libraries.
- Added a new example file `serializer_vectors.rs` that demonstrates serialization of different data types using the `runar_serializer` library.
- Updated `Cargo.toml` files to include the new package and ensure consistent dependency management across the workspace.
- Refactored existing dependencies in `rust-examples/Cargo.toml` for consistency with workspace naming conventions.
- Enhanced the overall project structure by organizing examples and ensuring clarity in the usage of serialization features.