### PR TITLE
Refactor FFI key management and enhance parameter validation

### DIFF
--- a/runar-ffi/include/runar_ffi.h
+++ b/runar-ffi/include/runar_ffi.h
@@ -105,8 +105,8 @@ int32_t rn_keys_register_apple_device_keystore(void *keys,
                                                struct RNAPIRnError *err);
 
 int32_t rn_keys_register_linux_device_keystore(void *keys,
-                                               const char *_service,
-                                               const char *_account,
+                                               const char *service,
+                                               const char *account,
                                                struct RNAPIRnError *err);
 
 int32_t rn_keys_node_encrypt_with_envelope(void *keys,


### PR DESCRIPTION
- Updated function signatures in `runar_ffi.h` and `lib.rs` to improve clarity by renaming parameters for consistency.
- Removed deprecated error handling function and streamlined validation logic in `rn_keys_register_apple_device_keystore` and `rn_keys_register_linux_device_keystore`.
- Enhanced error handling by validating parameters upfront, ensuring specific error messages for null arguments and invalid handles.
- Improved overall code maintainability and readability by restructuring function logic and enhancing comments.